### PR TITLE
Revert "Move OverlayView to below status bar on Oreo and above"

### DIFF
--- a/telecine/src/main/java/com/jakewharton/telecine/OverlayView.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/OverlayView.java
@@ -4,8 +4,6 @@ import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
 import android.support.annotation.NonNull;
 import android.view.Gravity;
 import android.view.View;
@@ -124,13 +122,6 @@ final class OverlayView extends FrameLayout {
   @Override public WindowInsets onApplyWindowInsets(WindowInsets insets) {
     if (systemOverlayAllowed) {
       getLayoutParams().height = insets.getSystemWindowInsetTop();
-    }
-
-    boolean canReceiveTouchEventsUnderStatusBar = VERSION.SDK_INT < VERSION_CODES.O;
-    if (!canReceiveTouchEventsUnderStatusBar) {
-      int statusBarHeight = insets.getSystemWindowInsetTop();
-      lp.height += statusBarHeight;
-      setPaddingRelative(getPaddingStart(), getPaddingTop() + statusBarHeight, getPaddingEnd(), getPaddingBottom());
     }
 
     listener.onResize();


### PR DESCRIPTION
Reverts Permik/Telecine#2

Accidentally pulled overlapping code.